### PR TITLE
SystemUI: Fix QS Clock Overflowing

### DIFF
--- a/packages/SystemUI/res/layout/quick_settings_header_info.xml
+++ b/packages/SystemUI/res/layout/quick_settings_header_info.xml
@@ -38,7 +38,7 @@
         android:format12Hour="hh:mm"
         android:layout_height="wrap_content"
         android:gravity="center"
-        android:textSize="55dp"/>
+        android:textSize="40dp"/>
 
     <com.android.systemui.statusbar.policy.DateView
         android:id="@+id/textDate"


### PR DESCRIPTION
Date part on QS clock is cut off so reduce size of time to fit.